### PR TITLE
Replaced exsiccati with exsiccata

### DIFF
--- a/data_importer/migrations/rename-exsiccata-vicecounty.sql
+++ b/data_importer/migrations/rename-exsiccata-vicecounty.sql
@@ -1,0 +1,19 @@
+/*
+migration: 20171214-1
+database: datastore_default
+description: renaming the keys exsiccati, exsiccatiNumber, and viceCountry.
+*/
+
+update ecatalogue
+set
+  properties = properties - 'exsiccatiNumber' - 'exsiccati' - 'viceCountry'
+    ||
+    jsonb_build_object('exsiccataNumber', properties -> 'exsiccatiNumber', 'exsiccata',
+                       properties -> 'exsiccati', 'viceCounty', properties -> 'viceCountry');
+
+-- should be 0 if successful
+select count(key) as "failed changes:"
+from (select jsonb_object_keys(properties) as key
+      from ecatalogue) as keys
+where
+  key in ('exsiccati', 'exsiccatiNumber', 'viceCountry');

--- a/data_importer/tasks/specimen.py
+++ b/data_importer/tasks/specimen.py
@@ -160,8 +160,8 @@ class SpecimenDatasetTask(DatasetTask):
         # Silica gel
         Field('ecatalogue', 'SilPopulationCode', 'populationCode'),
         # Botany
-        Field('ecatalogue', 'CollExsiccati', 'exsiccati'),
-        Field('ecatalogue', 'ColExsiccatiNumber', 'exsiccatiNumber'),
+        Field('ecatalogue', 'CollExsiccati', 'exsiccata'),
+        Field('ecatalogue', 'ColExsiccatiNumber', 'exsiccataNumber'),
         Field('ecatalogue', 'ColSiteDescription', 'labelLocality'),
         Field('ecatalogue', 'ColPlantDescription', 'plantDescription'),
         # Paleo


### PR DESCRIPTION
KE Emu fields still use exsiccati - this will have to be changed when it changes in KE Emu
partial fix for NaturalHistoryMuseum/ckanext-nhm#346