### PR TITLE
Account for negative lat/long

### DIFF
--- a/data_importer/tasks/specimen.py
+++ b/data_importer/tasks/specimen.py
@@ -236,10 +236,10 @@ class SpecimenDatasetTask(DatasetTask):
                 4326),
             3857) as _the_geom_webmercator
             FROM ecatalogue
-            WHERE ecatalogue.properties->>'decimalLatitude' ~ '^[0-9\.]+$'
+            WHERE ecatalogue.properties->>'decimalLatitude' ~ '^-?[0-9\.]+$'
                 AND cast(ecatalogue.properties->>'decimalLatitude' as FLOAT8) > -90
                 AND cast(ecatalogue.properties->>'decimalLatitude' as FLOAT8) < 90
-                AND ecatalogue.properties->>'decimalLongitude' ~ '^[0-9\.]+$'
+                AND ecatalogue.properties->>'decimalLongitude' ~ '^-?[0-9\.]+$'
                 AND cast(ecatalogue.properties->>'decimalLongitude' as FLOAT8) >= -180
                 AND cast(ecatalogue.properties->>'decimalLongitude' as FLOAT8) <= 180
             )


### PR DESCRIPTION
The regex used to filter out erroneous latitudes and longitudes from the data didn't account for negative values meaning points with a latitude and longitude > 0 were accepted.

Visual representation of the issue:

![maps](https://user-images.githubusercontent.com/4718259/34682185-09d6b6f4-f496-11e7-972a-d5e0dd9d41d6.png)
