### PR TITLE
fixed specimens filter; improved slack message

### DIFF
--- a/data_importer/lib/stats.py
+++ b/data_importer/lib/stats.py
@@ -98,6 +98,11 @@ class BaseMilestone(object):
             print(entry)
 
     def _slack_msg(self, record_dict):
+        """
+        Generate the slack message.
+        :param record_dict: the record to be posted about
+        :return:
+        """
         entry = self._log_entry(record_dict)
         data = {
             'attachments': [
@@ -143,16 +148,96 @@ class SpecimenMilestone(BaseMilestone):
 
     def __init__(self, *args, **kwargs):
         from data_importer.tasks import specimen_record_types
-        self.record_types = specimen_record_types
+        self.record_types = [i for i in specimen_record_types if 'Group Parent' not in i]
         super(SpecimenMilestone, self).__init__(*args, **kwargs)
 
     def match(self, record_dict):
-        return record_dict.get('record_type', None) in self.record_types
+        record_type = record_dict.get('record_type', None) in self.record_types
+        embargoed = record_dict.get('embargo_date', None) is not None
+        if embargoed:
+            try:
+                embargo_date = dt.strptime(record_dict.get('embargo_date'), '%Y%m%d')
+            except:
+                embargo_date = dt.now()
+        else:
+            embargo_date = dt.now()
+        embargo_passed = embargo_date <= dt.now()
+        return record_type and (not embargoed or embargo_passed)
+
+    @staticmethod
+    def _emoji(record_properties):
+        """
+        Find an emoji representing this record.
+        :param record_properties: the record's properties (as a dict)
+        :return: an emoji string representation (surrounded by colons)
+        """
+        emoji_dict = {
+            'BMNH(E)': {
+                None: ':bug:'
+                },
+            'BOT': {
+                None: ':deciduous_tree:',
+                'bryophytes': ':golf:',
+                'diatoms': ':eight_pointed_black_star:',
+                'flowering plants': ':blossom:',
+                'seed plants: brit & irish': ':seedling:'
+                },
+            'MIN': {
+                None: ':gem:'
+                },
+            'PAL': {
+                None: ':t-rex:',
+                'vertebrates': ':sauropod:',
+                'invertebrates': ':skull:',
+                'palaeobotany': ':fallen_leaf:'
+                },
+            'ZOO': {
+                None: ':penguin:',
+                'annelida': ':wavy_dash:',
+                'aves': ':bird:',
+                'cnidaria': ':space_invader:',
+                'crustacea': ':crab:',
+                'echinodermata': ':star:',
+                'mammalia': ':monkey_face:',
+                'mollusca': ':snail:',
+                'pisces': ':fish:',
+                'porifera': ':cloud:',
+                'reptiles & amphibians': ':snake:'
+                },
+            None: {
+                None: ':darwin:'
+                },
+            }
+
+        coll = record_properties.get('collectionCode', None).upper()
+        sub_dep = record_properties.get('subDepartment', None).lower()
+        coll_emojis = emoji_dict.get(coll, emoji_dict.get(None, {}))
+        emoji = coll_emojis.get(sub_dep, coll_emojis.get(None, None))
+        return emoji or ':question:'
+
+    @staticmethod
+    def _colour(record_properties):
+        """
+        Get a colour for the slack message.
+        :param record_properties: the record's properties (as a dict)
+        :return: a hex colour code
+        """
+        colour_dict = {
+            'BMNH(E)': '#563635',
+            'BOT': '#f4e04d',
+            'MIN': '#042d6b',
+            'PAL': '#5daf57',
+            'ZOO': '#af2d2d',
+            None: '#ca7df9',
+            }
+
+        coll = record_properties.get('collectionCode', None).upper()
+        return colour_dict.get(coll, '#ca7df9')
 
     def _slack_msg(self, record_dict):
         data = super(SpecimenMilestone, self)._slack_msg(record_dict)
         properties = record_dict['properties'].adapted
-        data['attachments'][0]['color'] = '#616ad3'
+        data['attachments'][0]['color'] = self._colour(properties)
         data['attachments'][0]['author_name'] = properties.get('recordedBy',
                                                                properties.get(
                                                                    'identifiedBy',
@@ -165,6 +250,7 @@ class SpecimenMilestone(BaseMilestone):
         data['attachments'][0][
             'title_link'] = 'http://data.nhm.ac.uk/object/' + record_dict.get(
             'guid')
+        data['attachments'][0]['footer'] = self._emoji(properties)
         created = properties.get('created', None)
         if created is not None:
             data['attachments'][0]['ts'] = dt.strptime(created, '%Y-%m-%d').timestamp()
@@ -173,5 +259,6 @@ class SpecimenMilestone(BaseMilestone):
     @property
     def query(self):
         record_types = "','".join(self.record_types)
-        return "select count(*) from ecatalogue where record_type in ('{0}')".format(
-            record_types)
+        return "select count(*) from ecatalogue where record_type in ('{0}') and (" \
+               "embargo_date is null or embargo_date < NOW()) and deleted is " \
+               "null".format(record_types)


### PR DESCRIPTION
record types list erroneously included 'parent' records and the match filter did not exclude embargoed records
slack message now includes an emoji footer and collection-based colours :tada: