### PR TITLE
Remove Bird Group Parent and Bird Group Part

### DIFF
--- a/data_importer/tasks/specimen.py
+++ b/data_importer/tasks/specimen.py
@@ -34,8 +34,6 @@ class SpecimenDatasetTask(DatasetTask):
         'DNA Prep',
         'Mammal Group Parent',  # Not included in the actual output; added to part records
         'Mammal Group Part',
-        "Bird Group Parent",
-        "Bird Group Part",
         'Bryozoa Part Specimen',
         'Silica Gel Specimen',
         "Parasite Card",


### PR DESCRIPTION
Both of these bird groups are not used anymore (or at least should not be used anymore) in Emu and therefore we do not need to accept them.