### PR TITLE
Only lower/upper the collection code/subdepartment if we get one

### DIFF
--- a/data_importer/lib/stats.py
+++ b/data_importer/lib/stats.py
@@ -228,8 +228,12 @@ class SpecimenMilestone(BaseMilestone):
                 },
             }
 
-        coll = record_properties.get('collectionCode', None).upper()
-        sub_dep = record_properties.get('subDepartment', None).lower()
+        coll = record_properties.get('collectionCode', None)
+        if coll:
+            coll = coll.upper()
+        sub_dep = record_properties.get('subDepartment', None)
+        if sub_dep:
+            sub_dep = sub_dep.lower()
         coll_emojis = emoji_dict.get(coll, emoji_dict.get(None, {}))
         emoji = coll_emojis.get(sub_dep, coll_emojis.get(None, None))
         return emoji or ':question:'


### PR DESCRIPTION
```python
ERROR: [pid 7148] Worker Worker(salt=886135655, workers=1, host=data-pgs-2.nhm.ac.uk, username=root, pid=7148) failed    EcatalogueTask(date=20180520)
Traceback (most recent call last):
  File "/usr/lib/data_importer/lib/python3.4/site-packages/luigi/worker.py", line 191, in run
    new_deps = self._run_get_new_deps()
  File "/usr/lib/data_importer/lib/python3.4/site-packages/luigi/worker.py", line 129, in _run_get_new_deps
    task_gen = self.task.run()
  File "/usr/lib/data_importer/src/data-importer/data_importer/tasks/keemu/base.py", line 202, in run
    self.milestone_check(record_dict)
  File "/usr/lib/data_importer/src/data-importer/data_importer/tasks/keemu/base.py", line 177, in milestone_check
    m.check(record_dict)
  File "/usr/lib/data_importer/src/data-importer/data_importer/lib/stats.py", line 157, in check
    self.slack(record_dict)
  File "/usr/lib/data_importer/src/data-importer/data_importer/lib/stats.py", line 141, in slack
    data = self._slack_msg(record_dict)
  File "/usr/lib/data_importer/src/data-importer/data_importer/lib/stats.py", line 267, in _slack_msg
    data['attachments'][0]['footer'] = self._emoji(properties)
  File "/usr/lib/data_importer/src/data-importer/data_importer/lib/stats.py", line 227, in _emoji
    sub_dep = record_properties.get('subDepartment', None).lower()
AttributeError: 'NoneType' object has no attribute 'lower'
```