### PR TITLE
Strip strings to clean up extra whitespaces

### DIFF
--- a/data_importer/lib/field.py
+++ b/data_importer/lib/field.py
@@ -34,6 +34,9 @@ class Field(object):
         v = self._get_value(record)
         if self.formatter:
             v = self.formatter(v)
+        if v and isinstance(v, str):
+            # remove any whitespace at either end of the actual data
+            v = v.strip()
         return v
 
     def has_value(self, record):


### PR DESCRIPTION
We already do this on presentation on the site but not anywhere else. This change does it on import to ensure all data is clean (in this regard).

Closes the data importer part of https://github.com/NaturalHistoryMuseum/data-portal/issues/211.