### PR TITLE
Allow pending emultimedia entries

### DIFF
--- a/data_importer/lib/column.py
+++ b/data_importer/lib/column.py
@@ -12,12 +12,17 @@ class Column(object):
     :param field_name: field name
     param field_name: postgres field type
     :param field_alias: the keemu field
+    :param formatter: a function that when given a value returns a formatted
+    version appropriate for this column. If no formatter is provided the value
+    is simply returned as is.
     """
-    def __init__(self, field_name, field_type, ke_field_name=None, indexed=False):
+    def __init__(self, field_name, field_type, ke_field_name=None,
+                 indexed=False, formatter=lambda v: v):
         self.field_name = field_name
         self.field_type = field_type
         self.ke_field_name = ke_field_name
         self.indexed = indexed
+        self.formatter = formatter
 
     def get_index_type(self):
         """

--- a/data_importer/migrations/add-pending-column-to-emultimedia.sql
+++ b/data_importer/migrations/add-pending-column-to-emultimedia.sql
@@ -12,3 +12,27 @@ alter table emultimedia add column pending boolean;
 -- better than using a default value when altering the table as we avoid locking
 -- the entire table whilst updating some 2million rows which will take a while.
 update emultimedia set pending = false;
+
+
+-- drop the materialized view _multimedia_view so that it can be redefined
+drop view _multimedia_view;
+-- redefine the materialized view
+CREATE MATERIALIZED VIEW _multimedia_view AS (
+    SELECT
+        _ecatalogue__emultimedia.irn,
+        COALESCE(jsonb_agg(
+            jsonb_build_object('identifier', format('http://www.nhm.ac.uk/services/media-store/asset/%s/contents/preview', emultimedia.properties->>'assetID'),
+            'type', 'StillImage',
+            'license',  'http://creativecommons.org/licenses/by/4.0/',
+            'rightsHolder',  'The Trustees of the Natural History Museum, London') || emultimedia.properties)
+            FILTER (WHERE emultimedia.irn IS NOT NULL), NULL)::TEXT as multimedia,
+        string_agg(DISTINCT emultimedia.properties->>'category', ';') as category
+    FROM emultimedia
+    INNER JOIN _ecatalogue__emultimedia ON _ecatalogue__emultimedia.rel_irn = emultimedia.irn
+    WHERE
+        (embargo_date IS NULL OR embargo_date < NOW())
+      AND deleted IS NULL
+      AND pending IS FALSE
+    GROUP BY _ecatalogue__emultimedia.irn);
+
+CREATE UNIQUE INDEX ON _multimedia_view (irn);

--- a/data_importer/migrations/add-pending-column-to-emultimedia.sql
+++ b/data_importer/migrations/add-pending-column-to-emultimedia.sql
@@ -1,0 +1,14 @@
+/*
+migration: 20180530-1
+database: datastore_default
+description: adding new pending column to emultimedia and setting all existing
+             values to false.
+*/
+
+-- add the new boolean column
+alter table emultimedia add column pending boolean;
+-- set the default value to false as all entries prior to this migration's run
+-- will not be pending. Setting the value on all existing rows like this is
+-- better than using a default value when altering the table as we avoid locking
+-- the entire table whilst updating some 2million rows which will take a while.
+update emultimedia set pending = false;

--- a/data_importer/tasks/keemu/base.py
+++ b/data_importer/tasks/keemu/base.py
@@ -320,7 +320,7 @@ class KeemuBaseTask(LuigiCopyToTable):
                 else:
                     value = getattr(record, column.ke_field_name, None)
 
-                column_dict[column.field_name] = value
+                column_dict[column.field_name] = column.formatter(value)
 
         return column_dict
 

--- a/data_importer/tasks/keemu/ecatalogue.py
+++ b/data_importer/tasks/keemu/ecatalogue.py
@@ -112,7 +112,7 @@ class EcatalogueTask(KeemuBaseTask):
                             'rightsHolder',  'The Trustees of the Natural History Museum, London') || emultimedia.properties)
                             FILTER (WHERE emultimedia.irn IS NOT NULL), NULL)::TEXT as multimedia,
                         string_agg(DISTINCT emultimedia.properties->>'category', ';') as category FROM emultimedia
-                        INNER JOIN _ecatalogue__emultimedia ON _ecatalogue__emultimedia.rel_irn = emultimedia.irn WHERE (embargo_date IS NULL OR embargo_date < NOW()) AND deleted IS NULL
+                        INNER JOIN _ecatalogue__emultimedia ON _ecatalogue__emultimedia.rel_irn = emultimedia.irn WHERE (embargo_date IS NULL OR embargo_date < NOW()) AND deleted IS NULL AND pending IS FALSE
                         GROUP BY _ecatalogue__emultimedia.irn); CREATE UNIQUE INDEX ON _multimedia_view (irn);
                 """
         else:

--- a/data_importer/tasks/keemu/emultimedia.py
+++ b/data_importer/tasks/keemu/emultimedia.py
@@ -4,15 +4,11 @@
 Created by Ben Scott on '30/08/2017'.
 """
 
-import abc
 import luigi
-from operator import is_not
-from operator import is_not, ne
-
-from data_importer.tasks.keemu.base import KeemuBaseTask
 from data_importer.lib.column import Column
-from data_importer.lib.operators import is_one_of, is_not_one_of
 from data_importer.lib.filter import Filter
+from data_importer.tasks.keemu.base import KeemuBaseTask
+from operator import is_not
 
 
 class EMultimediaTask(KeemuBaseTask):
@@ -24,13 +20,14 @@ class EMultimediaTask(KeemuBaseTask):
     # Additional columns for emultimedia module - add embargo date
     columns = KeemuBaseTask.columns + [
         Column('embargo_date', "DATE", ["NhmSecEmbargoDate", "NhmSecEmbargoExtensionDate"], True),
+        # note the use of the formatter parameter to turn the value into a bool
+        Column('pending', 'BOOLEAN', 'GenDigitalMediaId', True, lambda g: g == 'Pending')
     ]
 
     # Apply filters to each record, and do not import if any fail
     record_filters = KeemuBaseTask.record_filters + [
         Filter('GenDigitalMediaId', [
-            (is_not, None),
-            (ne, 'Pending')
+            (is_not, None)
         ]),
     ]
 


### PR DESCRIPTION
Allowing pending `emultimedia` entries ensures we capture all relationships from `ecatalogue` -> `emultimedia` as often the definition of the relationship comes through in the same day's dump as the new `emultimedia` entry which is still pending at that point.

Once this is deployed it will solve the issues going forward, however it will require either a rerun over the old `emultimedia` dumps all the way back to the last full dump (2017/08/30) or it will need a backfill of missing links via some script. The script backfill method is preferred.

Database changes are included in this PR in the migration `add-pending-column-to-emultimedia.sql`. This includes:

- adding the `pending` column to the `emultimedia` table.
- deletion and redefinition of the materialized view `_multimedia_view`.
