### PR TITLE
Set new version number

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "data-importer"
-version = "3.0.0a"
+version = "1.0.0"
 description = "Pipeline for importing data from EMu into the NHM Data Portal"
 readme = "README.md"
 requires-python = ">=3.8"
@@ -71,7 +71,7 @@ exclude = ["tests", "docs"]
 
 [tool.commitizen]
 name = "cz_nhm"
-version = "2.0.0"
+version = "1.0.0"
 tag_format = "v$version"
 update_changelog_on_bump = true
 changelog_incremental = false


### PR DESCRIPTION
There were no tags in this repo and no version numbers so this is fresh. The old data-importer2 only got to v0.1.4 so might as well just start at v1.0.0.