### PR TITLE
Add dimp as a cli script

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -56,11 +56,12 @@ docs = [
 repository = "https://github.com/NaturalHistoryMuseum/data-importer"
 changelog = "https://github.com/NaturalHistoryMuseum/data-importer/blob/main/CHANGELOG.md"
 
+[project.scripts]
+dimp = "dataimporter.cli.main:cli"
 
 [build-system]
 requires = ["setuptools", "wheel"]
 build-backend = "setuptools.build_meta"
-
 
 [tool]
 [tool.setuptools]


### PR DESCRIPTION
So that you can use `dimp` instead of `python -m dataimporter.cli`.