### PR TITLE
Add controlled locking to ensure one importer is running at once

### DIFF
--- a/dataimporter/cli/emu.py
+++ b/dataimporter/cli/emu.py
@@ -1,10 +1,10 @@
-import click
 import math
 
-from dataimporter.cli.utils import with_config, console
-from dataimporter.importer import DataImporter
-from dataimporter.lib.config import Config
+import click
 
+from dataimporter.cli.utils import console, with_config
+from dataimporter.importer import use_importer
+from dataimporter.lib.config import Config
 
 EMU_VIEWS = ("specimen", "indexlot", "artefact", "mss", "preparation")
 
@@ -35,7 +35,7 @@ def auto(config: Config, one: bool = False, delay_sync: bool = False):
     Processes all the available EMu exports, queuing, ingesting, and indexing one day's
     worth of data at a time ensuring each day's data is represented by a new version.
     """
-    with DataImporter(config) as importer:
+    with use_importer(config) as importer:
         while True:
             console.log("Queuing next dump set")
             date_queued = importer.queue_emu_changes()
@@ -89,7 +89,7 @@ def queue(amount: str, config: Config):
         assert amount > 0, "Amount must be greater than 0"
         console.log(f"Queuing next {amount} dumpsets")
 
-    with DataImporter(config) as importer:
+    with use_importer(config) as importer:
         console.log(f"Current latest queued dumpset date: {importer.emu_status.get()}")
 
         while amount > 0:
@@ -109,5 +109,5 @@ def get_emu_date(config: Config):
     """
     Prints the latest date we've imported EMu exports for.
     """
-    with DataImporter(config) as importer:
+    with use_importer(config) as importer:
         console.log(importer.emu_status.get())

--- a/dataimporter/cli/ext.py
+++ b/dataimporter/cli/ext.py
@@ -1,7 +1,7 @@
 import click
 
 from dataimporter.cli.utils import console, with_config
-from dataimporter.importer import DataImporter
+from dataimporter.importer import use_importer
 from dataimporter.lib.config import Config
 
 
@@ -21,7 +21,7 @@ def gbif(config: Config):
     if not config.gbif_username or not config.gbif_password:
         console.log("[red]gbif_username and gbif_password must be set")
 
-    with DataImporter(config) as importer:
+    with use_importer(config) as importer:
         console.log("Queuing new GBIF changes")
         importer.queue_gbif_changes()
         console.log("Updating specimen data in MongoDB")

--- a/dataimporter/cli/main.py
+++ b/dataimporter/cli/main.py
@@ -8,9 +8,9 @@ from dataimporter.cli.emu import emu_group
 from dataimporter.cli.ext import ext_group
 from dataimporter.cli.maintenance import maintenance_group
 from dataimporter.cli.portal import portal_group
-from dataimporter.cli.utils import with_config, console
+from dataimporter.cli.utils import console, with_config
 from dataimporter.cli.view import view_group
-from dataimporter.importer import DataImporter
+from dataimporter.importer import use_importer
 from dataimporter.lib.config import Config
 
 
@@ -28,7 +28,7 @@ def get_status(config: Config):
     """
     Prints some status information about the importer's data.
     """
-    with DataImporter(config) as importer:
+    with use_importer(config) as importer:
         console.log("Currently using config from", config.source)
         console.log("Latest EMu export queued:", importer.emu_status.get())
         console.log(Rule())

--- a/dataimporter/cli/maintenance.py
+++ b/dataimporter/cli/maintenance.py
@@ -3,8 +3,8 @@ import code
 import click
 
 from dataimporter.cli.shell import setup_env
-from dataimporter.cli.utils import with_config, console
-from dataimporter.importer import DataImporter
+from dataimporter.cli.utils import console, with_config
+from dataimporter.importer import use_importer
 from dataimporter.lib.config import Config
 
 
@@ -21,7 +21,7 @@ def merge(config: Config):
 
     This cleans up deleted documents etc.
     """
-    with DataImporter(config) as importer:
+    with use_importer(config) as importer:
         for view in importer.views:
             if view.is_published:
                 console.log(f"Force merge on {view.name} indices")
@@ -38,7 +38,7 @@ def shell(config: Config):
 
     This is provided as purely a debugging tool, use at your own risk!
     """
-    with DataImporter(config) as importer:
+    with use_importer(config) as importer:
         console.print("Starting shell...")
         env = setup_env(importer)
         banner = f"Available variables/functions: {', '.join(env.keys())}"

--- a/dataimporter/cli/view.py
+++ b/dataimporter/cli/view.py
@@ -1,7 +1,7 @@
 import click
 
-from dataimporter.cli.utils import with_config, console
-from dataimporter.importer import DataImporter
+from dataimporter.cli.utils import console, with_config
+from dataimporter.importer import use_importer
 from dataimporter.lib.config import Config
 
 
@@ -16,7 +16,7 @@ def list_views(config: Config):
     """
     List the name of all the views in current use.
     """
-    with DataImporter(config) as importer:
+    with use_importer(config) as importer:
         console.log(", ".join(view.name for view in importer.views))
 
 
@@ -31,7 +31,7 @@ def flush(view: str, config: Config):
     first, just to make sure) but for published views you should make sure you know what
     you're doing.
     """
-    with DataImporter(config) as importer:
+    with use_importer(config) as importer:
         view = importer.get_view(view)
         console.log(
             f"Flushing {view.name} view queue, currently has", view.count(), "IDs in it"
@@ -57,7 +57,7 @@ def ingest(view: str, config: Config, everything: bool = False):
     On the given view, updates MongoDB with any queued EMu changes and flushes its
     queue.
     """
-    with DataImporter(config) as importer:
+    with use_importer(config) as importer:
         console.log(f"Adding changes from {view} view to mongo")
         importer.add_to_mongo(view, everything=everything)
         console.log(f"Added changes from {view} view to mongo")
@@ -78,7 +78,7 @@ def sync(view: str, config: Config, resync: bool = False):
     """
     Updates Elasticsearch with the changes in MongoDB for the given view.
     """
-    with DataImporter(config) as importer:
+    with use_importer(config) as importer:
         console.log(f"Syncing changes from {view} view to elasticsearch")
         importer.sync_to_elasticsearch(view, resync=resync)
         console.log(f"Finished with {view}")

--- a/dataimporter/lib/config.py
+++ b/dataimporter/lib/config.py
@@ -67,6 +67,15 @@ class Config:
     def get_mongo_database_name(self) -> str:
         return self.mongo_config.database
 
+    @property
+    def lock_file(self) -> Path:
+        """
+        Path to the lock file to be used for the data directory.
+
+        :return: the Path to the lock file
+        """
+        return self.data_path / "importer.lock"
+
 
 class ConfigLoadError(Exception):
     def __init__(self, reason: str):

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -33,6 +33,7 @@ dependencies = [
     "rich==13.6.0",
     "psycopg[binary]==3.1.18",
     "PyYAML==6.0.2",
+    "filelock==3.16.1",
 ]
 [project.optional-dependencies]
 test = [


### PR DESCRIPTION
LevelDB implements locking on its databases to ensure cross-process isn't happening, but that results in nasty exceptions which are confusing. We could wrap them, but doing that means we're relying on LevelDB raising this error consistently which feels a bit meh, better to just have our own lock in place and check that. This commit has a new dependency for filelock which is used to create a file in the dimp data directory which controls access.

Closes: #52