### PR TITLE
Fix typo in department name

### DIFF
--- a/dataimporter/emu/views/specimen.py
+++ b/dataimporter/emu/views/specimen.py
@@ -51,7 +51,7 @@ BASIS_OF_RECORD_LOOKUP = {
     "Botany": "PreservedSpecimen",
     "Entomology": "PreservedSpecimen",
     "Zoology": "PreservedSpecimen",
-    "Paleontology": "FossilSpecimen",
+    "Palaeontology": "FossilSpecimen",
     "Mineralogy": "Occurrence",
 }
 


### PR DESCRIPTION
All our palaeo records currently have no `basisOfRecord` field because the `ColDepartment` lookup is failing to find "Palaeontology" in the keys.