### PR TITLE
Bump workflow

### DIFF
--- a/.github/workflows/bump.yml
+++ b/.github/workflows/bump.yml
@@ -1,0 +1,31 @@
+name: Bump version
+
+on:
+  push:
+    branches:
+      - main
+
+jobs:
+  bump-version:
+    name: Bump version and create changelog
+    runs-on: ubuntu-latest
+    if: "!startsWith(github.event.head_commit.message, 'bump:')"
+    steps:
+      - name: Checkout source code
+        uses: actions/checkout@v4
+        with:
+          token: ${{ secrets.PERSONAL_ACCESS_TOKEN }}
+          fetch-depth: 0
+      - name: Create bump and changelog
+        uses: commitizen-tools/commitizen-action@master
+        with:
+          github_token: ${{ secrets.PERSONAL_ACCESS_TOKEN }}
+          changelog_increment_filename: CURRENT.md
+          extra_requirements: "cz-nhm"
+      - name: Release
+        uses: softprops/action-gh-release@v1
+        with:
+          body_path: "CURRENT.md"
+          tag_name: v${{ env.REVISION }}
+        env:
+          GITHUB_TOKEN: ${{ secrets.PERSONAL_ACCESS_TOKEN }}

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "data-importer"
-version = "1.0.1"
+version = "1.1.0"
 description = "Pipeline for importing data from EMu into the NHM Data Portal"
 readme = "README.md"
 requires-python = ">=3.8"
@@ -73,7 +73,7 @@ exclude = ["tests", "docs"]
 
 [tool.commitizen]
 name = "cz_nhm"
-version = "1.0.1"
+version = "1.1.0"
 tag_format = "v$version"
 update_changelog_on_bump = true
 changelog_incremental = false


### PR DESCRIPTION
Fix the project version and add a bump workflow to automate releases.

More standardisation work is needed (e.g. ruff config) but this at least should prevent versions getting out of sync.