### PR TITLE
Purge non members and non-publishable records from views

### DIFF
--- a/dataimporter/cli/shell.py
+++ b/dataimporter/cli/shell.py
@@ -63,11 +63,13 @@ def check_membership(importer: DataImporter, name: str, record_id: Union[str, in
     member_result = view.is_member(record)
     publish_result = view.is_publishable(record)
     if member_result and publish_result:
-        print(f'{record_id} is a currently published member of {name}')
+        console.print(f'{record_id} is a currently published member of {name}')
     elif member_result and not publish_result:
-        print(
+        console.print(
             f'{record_id} is a member of {name}, but is not published due to '
             f'{publish_result.reason}'
         )
     else:
-        print(f"{record_id} is not a member of {name} due to '{member_result.reason}'")
+        console.print(
+            f"{record_id} is not a member of {name} due to '{member_result.reason}'"
+        )

--- a/dataimporter/cli/view.py
+++ b/dataimporter/cli/view.py
@@ -82,3 +82,24 @@ def sync(view: str, config: Config, resync: bool = False):
         console.log(f'Syncing changes from {view} view to elasticsearch')
         importer.sync_to_elasticsearch(view, resync=resync)
         console.log(f'Finished with {view}')
+
+
+@view_group.command('purge')
+@click.argument('view', type=str)
+@with_config
+def purge(view: str, config: Config):
+    """
+    Purge non-member and non-publishable records from a view.
+
+    Non-publishable records should be handled by the ingest process, but the occurrence
+    of records that stop being members of a view should be much rarer so this needs to
+    be run on a semi-regular basis to account for those.
+    """
+    with use_importer(config) as importer:
+        console.log(f'Purging non-member and non-publishable records from {view}')
+        non_member, non_publishable, total_deleted = importer.purge_unsuitable_records(
+            view
+        )
+        console.log(f'{non_member} non-member records found')
+        console.log(f'{non_publishable} non-publishable records found')
+        console.log(f'{total_deleted} records deleted')

--- a/dataimporter/emu/views/preparation.py
+++ b/dataimporter/emu/views/preparation.py
@@ -230,7 +230,7 @@ class PreparationView(View):
 
                 parent = self.store.get_record(parent_id)
                 if parent:
-                    if self.specimen_view.is_member(parent):
+                    if self.specimen_view.is_publishable_member(parent):
                         # we found a specimen, return the data from it
                         return self.specimen_view.transform(parent)
                     else:

--- a/dataimporter/lib/view.py
+++ b/dataimporter/lib/view.py
@@ -158,7 +158,7 @@ class View:
         yield from (
             record
             for record in self.store.get_records(ids, yield_deleted=False)
-            if self.is_member(record)
+            if self.is_publishable_member(record)
         )
 
     def get(self, record_id: str) -> Optional[SourceRecord]:
@@ -170,7 +170,7 @@ class View:
         :return: None or a SourceRecord object
         """
         record = self.store.get_record(record_id, return_deleted=False)
-        if record is not None and self.is_member(record):
+        if record is not None and self.is_publishable_member(record):
             return record
         return None
 

--- a/tests/test_importer.py
+++ b/tests/test_importer.py
@@ -5,6 +5,7 @@ from unittest.mock import MagicMock, patch
 
 import pytest
 from freezegun import freeze_time
+from splitgill.model import Record
 from splitgill.search import keyword
 from splitgill.utils import to_timestamp
 
@@ -717,6 +718,138 @@ class TestDataImporter:
             )
             # check it still exists in the previous version
             assert database.search(first_version).count() == 8
+
+    @pytest.mark.usefixtures('reset_mongo', 'reset_elasticsearch')
+    def test_purge_records(self, config: Config):
+        name = 'artefact'
+        # create some artefact records
+        artefact_records = [
+            create_ecatalogue(
+                str(i),
+                EcatalogueType[name],
+                PalArtObjectName=f'{i} beans',
+            )
+            for i in range(1, 9)
+        ]
+        first_dump_date = date(2025, 1, 1)
+        # create an ecatalogue dump with 8 artefacts
+        create_dump(
+            config.dumps_path,
+            'ecatalogue',
+            first_dump_date,
+            *artefact_records,
+        )
+        # make two records unpublishable and one no longer an artefact
+        depublished_record_1 = artefact_records[0]
+        depublished_record_1['SecRecordStatus'] = 'Retired'
+        depublished_record_2 = artefact_records[1]
+        depublished_record_2['AdmPublishWebNoPasswordFlag'] = 'N'
+        non_member_record = artefact_records[2]
+        non_member_record['ColRecordType'] = 'Banana'
+        test_records = [depublished_record_1, depublished_record_2, non_member_record]
+        # update the name for all of them so mongo recognises it as a change later
+        for ix, tr in enumerate(test_records):
+            tr.update({'PalArtObjectName': f'{ix} beanz'})
+        second_dump = create_dump(
+            config.dumps_path, 'ecatalogue', date(2025, 1, 3), *test_records
+        )
+
+        with use_importer(config) as importer, freeze_time('2025-01-02') as frozen_time:
+            view = importer.get_view(name)
+            db = importer.get_database(view)
+
+            # import the first dump and check all 8 records are present
+            importer.queue_emu_changes()
+            importer.add_to_mongo(name)
+            database = importer.get_database(importer.get_view(name))
+            importer.sync_to_elasticsearch(name)
+            first_db_version = database.get_committed_version()
+            first_es_version = database.get_elasticsearch_version()
+            search_base = database.search()
+
+            assert database.data_collection.count_documents({}) == 8
+            assert search_base.count() == 8
+
+            for test_record in test_records:
+                mongo_record = database.data_collection.find_one(
+                    {'id': test_record['irn']}
+                )
+                assert mongo_record is not None
+                assert len(mongo_record['data']) > 0
+                assert 'diffs' not in mongo_record
+                assert (
+                    search_base.filter(
+                        'term',
+                        **{keyword('_id'): test_record['irn']},
+                    ).count()
+                    == 1
+                )
+
+            frozen_time.tick(timedelta(days=2))  # advance forward 2 days
+
+            # force update the two invalid records (doing a normal ingest would
+            # automatically remove the depublished record)
+            source_records = [
+                SourceRecord(r['irn'], r, second_dump.name) for r in test_records
+            ]
+            view.store.put(source_records)
+            records = [Record(r.id, view.transform(r)) for r in source_records]
+            db.ingest(records, modified_field='modified')
+            second_db_version = db.get_committed_version()
+            assert second_db_version != first_db_version
+            importer.sync_to_elasticsearch(name)
+            second_es_version = db.get_elasticsearch_version()
+            assert second_es_version != first_es_version
+
+            # check all 8 records are still present and contain data
+            assert database.data_collection.count_documents({}) == 8
+            assert search_base.count() == 8
+            for test_record in test_records:
+                mongo_record = database.data_collection.find_one(
+                    {'id': test_record['irn']}
+                )
+                assert mongo_record is not None
+                assert len(mongo_record['data']) > 0
+                # check the source record has been updated
+                source_record = view.store.get_record(mongo_record['id'])
+                assert not view.is_publishable_member(source_record)
+                assert (
+                    search_base.filter(
+                        'term',
+                        **{keyword('artefactName'): test_record['PalArtObjectName']},
+                    ).count()
+                    == 1
+                )
+
+            frozen_time.tick(timedelta(days=1))  # advance forward 1 day
+
+            # now purge and check that they're all deleted
+            non_member_count, non_publishable_count, total_deleted = (
+                importer.purge_unsuitable_records(name)
+            )
+            final_db_version = db.get_committed_version()
+            assert final_db_version != second_db_version
+            importer.sync_to_elasticsearch(name)
+            final_es_version = db.get_elasticsearch_version()
+            assert final_es_version != second_es_version
+            assert non_member_count == 1
+            assert non_publishable_count == 2
+            assert total_deleted == 3
+            # they should still exist in mongo
+            assert database.data_collection.count_documents({}) == 8
+            # but they shouldn't have any current data
+            for test_record in test_records:
+                mongo_record = database.data_collection.find_one(
+                    {'id': test_record['irn']}
+                )
+                assert mongo_record is not None
+                assert len(mongo_record['data']) == 0
+                assert len(mongo_record['diffs']) == 2
+            # they shouldn't exist in current elasticsearch
+            assert search_base.count() == 5
+            # but they should in the previous versions
+            assert database.search(first_es_version).count() == 8
+            assert database.search(second_es_version).count() == 8
 
 
 class TestEMuStatus:


### PR DESCRIPTION
This adds functionality and commands to delete records (not redact) that have been updated so that they no longer match the `is_member` or `is_publishable` criteria of the view they are currently published under. Without being purged, these records would continue to be published in the current version of the view, but would not receive any updates.

This is an extension to #60 after discovering that there are also a small number of records that are no longer members but are still published. Changing the logic to account for these in the existing process would both increase the run time dramatically and also probably take a substantial amount of dev time; since it's such a small number, it's almost certainly not worth it. Running this on a regular basis is much quicker and easier, though it does of course add a small amount of extra admin.

The drop in coverage is mostly because I added a function for the shell to find these records and the CLI is not covered at the moment. All of the actually dangerous functionality is covered.