### PR TITLE
Splitgill upgrade + tests for republished records

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -19,7 +19,7 @@ classifiers = [
     "Programming Language :: Python :: 3.11",
 ]
 dependencies = [
-    "splitgill==3.1.0",
+    "splitgill==3.1.1",
     "elasticsearch==8.10.1",
     "elasticsearch-dsl==8.9.0",
     "pymongo==4.6.0",


### PR DESCRIPTION
Adds a test to check if records can be re-added after having previously been deleted (e.g. if a record is temporarily set to not publish on web). Requires splitgill v3.1.1.
