### PR TITLE
Release 2025-09-04

### DIFF
--- a/dataimporter/cli/shell.py
+++ b/dataimporter/cli/shell.py
@@ -21,6 +21,7 @@ def setup_env(importer: DataImporter) -> dict:
         'pmd': partial(print_record_data, importer, 'emultimedia'),
         'pgd': partial(print_record_data, importer, 'gbif'),
         'cm': partial(check_membership, importer),
+        'find_unsuitable': partial(find_unsuitable_records, importer),
     }
 
 
@@ -114,6 +115,7 @@ def find_unsuitable_records(
         is_member = view.is_member(source_record)
         if not is_member:
             not_member += 1
+            non_member_records.append([source_record.id, is_member.reason])
             continue
         is_publishable = view.is_publishable(source_record)
         if not is_publishable:

--- a/dataimporter/cli/shell.py
+++ b/dataimporter/cli/shell.py
@@ -1,5 +1,5 @@
 from functools import partial
-from typing import Union
+from typing import Dict, List, Tuple, Union
 
 from dataimporter.cli.utils import console
 from dataimporter.importer import DataImporter
@@ -63,11 +63,70 @@ def check_membership(importer: DataImporter, name: str, record_id: Union[str, in
     member_result = view.is_member(record)
     publish_result = view.is_publishable(record)
     if member_result and publish_result:
-        print(f'{record_id} is a currently published member of {name}')
+        console.print(f'{record_id} is a currently published member of {name}')
     elif member_result and not publish_result:
-        print(
+        console.print(
             f'{record_id} is a member of {name}, but is not published due to '
             f'{publish_result.reason}'
         )
     else:
-        print(f"{record_id} is not a member of {name} due to '{member_result.reason}'")
+        console.print(
+            f"{record_id} is not a member of {name} due to '{member_result.reason}'"
+        )
+
+
+def find_unsuitable_records(
+    importer: DataImporter, view_name: str, skip_deleted: bool = True
+) -> Dict[str, List[Tuple[str, str]]]:
+    """
+    Finds and returns lists of records in a view that are no longer members or no longer
+    match the publishing rules.Effectively a dry run of purge_unsuitable_records.
+
+    :param importer: a DataImporter instance
+    :param view_name: name of the view
+    :param skip_deleted: whether to skip deleted records when iterating over mongo
+        records (True, default), or return a report on these too (False)
+    :return: a dict
+    """
+    non_publishable_records = []
+    non_member_records = []
+    view = importer.get_view(view_name)
+    db = importer.get_database(view_name)
+    total = 0
+    deleted = 0
+    missing_source = 0
+    not_member = 0
+    not_publishable = 0
+    acceptable = 0
+    if skip_deleted:
+        filter_kwargs = {'filter': {'data._id': {'$exists': True}}}
+    else:
+        filter_kwargs = {}
+    for mongo_record in db.iter_records(**filter_kwargs):
+        total += 1
+        if mongo_record.is_deleted:
+            deleted += 1
+            continue
+        source_record = view.store.get_record(mongo_record.id)
+        if not source_record:
+            missing_source += 1
+            continue
+        is_member = view.is_member(source_record)
+        if not is_member:
+            not_member += 1
+            continue
+        is_publishable = view.is_publishable(source_record)
+        if not is_publishable:
+            not_publishable += 1
+            non_publishable_records.append([source_record.id, is_publishable.reason])
+            continue
+        acceptable += 1
+    console.print(
+        f'total: {total} | deleted: {deleted} | missing: {missing_source} | not '
+        f'members: {not_member} | not publishable: {not_publishable} | acceptable: '
+        f'{acceptable}'
+    )
+    return {
+        'not_publishable': non_publishable_records,
+        'not_member': non_member_records,
+    }

--- a/dataimporter/cli/shell.py
+++ b/dataimporter/cli/shell.py
@@ -60,8 +60,14 @@ def check_membership(importer: DataImporter, name: str, record_id: Union[str, in
     if record is None:
         console.print('record not found', style='red')
         return
-    result = view.is_member(record)
-    if result:
-        print(f'{record_id} is a member of {name}')
+    member_result = view.is_member(record)
+    publish_result = view.is_publishable(record)
+    if member_result and publish_result:
+        print(f'{record_id} is a currently published member of {name}')
+    elif member_result and not publish_result:
+        print(
+            f'{record_id} is a member of {name}, but is not published due to '
+            f'{publish_result.reason}'
+        )
     else:
-        print(f"{record_id} is not a member of {name} due to '{result.reason}'")
+        print(f"{record_id} is not a member of {name} due to '{member_result.reason}'")

--- a/dataimporter/cli/view.py
+++ b/dataimporter/cli/view.py
@@ -86,7 +86,7 @@ def sync(view: str, config: Config, resync: bool = False):
 
 @view_group.command('purge')
 @click.argument('view', type=str)
-@with_config
+@with_config()
 def purge(view: str, config: Config):
     """
     Purge non-member and non-publishable records from a view.

--- a/dataimporter/cli/view.py
+++ b/dataimporter/cli/view.py
@@ -82,3 +82,24 @@ def sync(view: str, config: Config, resync: bool = False):
         console.log(f'Syncing changes from {view} view to elasticsearch')
         importer.sync_to_elasticsearch(view, resync=resync)
         console.log(f'Finished with {view}')
+
+
+@view_group.command('purge')
+@click.argument('view', type=str)
+@with_config
+def purge(view: str, config: Config):
+    """
+    Purge non-member and non-publishable records from a view.
+
+    Non-publishable records should be handled by the ingest process, but the occurrence
+    of records that stop being members of a view should be much rarer so this needs to
+    be run on a semi-regular basis to account for those.
+    """
+    with use_importer(config) as importer:
+        console.log(f'Purging non-member and non-publishable records from {view}')
+        non_member, non_publishable, total_deleted = importer.purge_unsuitable_records(
+            view
+        )
+        console.log(f'{non_member} non-member records found')
+        console.log(f'{non_publishable} non-publishable records found')
+        console.log(f'{total_deleted} records deleted')

--- a/dataimporter/emu/views/artefact.py
+++ b/dataimporter/emu/views/artefact.py
@@ -52,6 +52,19 @@ class ArtefactView(View):
         if record.get_first_value('ColRecordType') != 'Artefact':
             return INVALID_TYPE
 
+        if record.get_first_value('ColDepartment') not in DEPARTMENT_COLLECTION_CODES:
+            return INVALID_DEPARTMENT
+
+        return SUCCESS_RESULT
+
+    def is_publishable(self, record: SourceRecord) -> FilterResult:
+        """
+        Filters the given record, determining whether it matches the publishing rules
+        for the artefact resource.
+
+        :param record: the record to filter
+        :return: a FilterResult object
+        """
         if not is_web_published(record):
             return NO_PUBLISH
 
@@ -60,9 +73,6 @@ class ArtefactView(View):
 
         if record.get_first_value('SecRecordStatus') in DISALLOWED_STATUSES:
             return INVALID_STATUS
-
-        if record.get_first_value('ColDepartment') not in DEPARTMENT_COLLECTION_CODES:
-            return INVALID_DEPARTMENT
 
         return SUCCESS_RESULT
 

--- a/dataimporter/emu/views/image.py
+++ b/dataimporter/emu/views/image.py
@@ -42,6 +42,16 @@ class ImageView(View):
         if record.get_first_value('MulMimeType') != 'image':
             return MULTIMEDIA_NOT_IMAGE
 
+        return SUCCESS_RESULT
+
+    def is_publishable(self, record: SourceRecord) -> FilterResult:
+        """
+        Filters the given record, determining whether it matches the publishing rules
+        for images.
+
+        :param record: the record to filter
+        :return: a FilterResult object
+        """
         if not is_valid_guid(record):
             return INVALID_GUID
 

--- a/dataimporter/emu/views/indexlot.py
+++ b/dataimporter/emu/views/indexlot.py
@@ -61,6 +61,19 @@ class IndexLotView(View):
         if record.get_first_value('ColRecordType') != 'Index Lot':
             return INVALID_TYPE
 
+        if record.get_first_value('ColDepartment') not in DEPARTMENT_COLLECTION_CODES:
+            return INVALID_DEPARTMENT
+
+        return SUCCESS_RESULT
+
+    def is_publishable(self, record: SourceRecord) -> FilterResult:
+        """
+        Filters the given record, determining whether it matches the publishing rules
+        for the index lots resource.
+
+        :param record: the record to filter
+        :return: a FilterResult object
+        """
         if not is_web_published(record):
             return NO_PUBLISH
 
@@ -69,9 +82,6 @@ class IndexLotView(View):
 
         if record.get_first_value('SecRecordStatus') in DISALLOWED_STATUSES:
             return INVALID_STATUS
-
-        if record.get_first_value('ColDepartment') not in DEPARTMENT_COLLECTION_CODES:
-            return INVALID_DEPARTMENT
 
         return SUCCESS_RESULT
 

--- a/dataimporter/emu/views/mammalpart.py
+++ b/dataimporter/emu/views/mammalpart.py
@@ -26,14 +26,9 @@ class MammalPartView(View):
         :param record: the record to filter
         :return: a FilterResult object
         """
-        if not is_web_published(record):
-            return NO_PUBLISH
 
         if record.get_first_value('ColRecordType', lower=True) != 'mammal group part':
             return INVALID_TYPE
-
-        if record.get_first_value('SecRecordStatus') in DISALLOWED_STATUSES:
-            return INVALID_STATUS
 
         if record.get_first_value('ColDepartment', lower=True) != 'zoology':
             return INVALID_DEPARTMENT
@@ -43,6 +38,22 @@ class MammalPartView(View):
 
         if 'CatKindOfObject' not in record:
             return MISSING_KIND_OF_OBJECT
+
+        return SUCCESS_RESULT
+
+    def is_publishable(self, record: SourceRecord) -> FilterResult:
+        """
+        Filters the given record, determining whether it matches the publishing rules
+        for mammal parts.
+
+        :param record: the record to filter
+        :return: a FilterResult object
+        """
+        if not is_web_published(record):
+            return NO_PUBLISH
+
+        if record.get_first_value('SecRecordStatus') in DISALLOWED_STATUSES:
+            return INVALID_STATUS
 
         return SUCCESS_RESULT
 

--- a/dataimporter/emu/views/mss.py
+++ b/dataimporter/emu/views/mss.py
@@ -34,14 +34,24 @@ class MSSView(View):
         if record.get_first_value('MulMimeType') != 'image':
             return MULTIMEDIA_NOT_IMAGE
 
+        if not record.get_first_value('DocIdentifier'):
+            return MULTIMEDIA_NO_IDENTIFIER
+
+        return SUCCESS_RESULT
+
+    def is_publishable(self, record: SourceRecord) -> FilterResult:
+        """
+        Filters the given record, determining whether it matches the publishing rules
+        for MSS records.
+
+        :param record: the record to filter
+        :return: a FilterResult object
+        """
         if not is_valid_guid(record):
             return INVALID_GUID
 
         if not is_web_published(record):
             return NO_PUBLISH
-
-        if not record.get_first_value('DocIdentifier'):
-            return MULTIMEDIA_NO_IDENTIFIER
 
         return SUCCESS_RESULT
 

--- a/dataimporter/emu/views/preparation.py
+++ b/dataimporter/emu/views/preparation.py
@@ -128,6 +128,19 @@ class PreparationView(View):
             # any other type is invalid
             return INVALID_TYPE
 
+        if record.get_first_value('ColDepartment') not in DEPARTMENT_COLLECTION_CODES:
+            return INVALID_DEPARTMENT
+
+        return SUCCESS_RESULT
+
+    def is_publishable(self, record: SourceRecord) -> FilterResult:
+        """
+        Filters the given record, determining whether it matches the publishing rules
+        for preps records.
+
+        :param record: the record to filter
+        :return: a FilterResult object
+        """
         if not is_web_published(record):
             return NO_PUBLISH
 
@@ -136,9 +149,6 @@ class PreparationView(View):
 
         if record.get_first_value('SecRecordStatus') in DISALLOWED_STATUSES:
             return INVALID_STATUS
-
-        if record.get_first_value('ColDepartment') not in DEPARTMENT_COLLECTION_CODES:
-            return INVALID_DEPARTMENT
 
         if is_on_loan(record):
             return ON_LOAN

--- a/dataimporter/emu/views/preparation.py
+++ b/dataimporter/emu/views/preparation.py
@@ -230,7 +230,7 @@ class PreparationView(View):
 
                 parent = self.store.get_record(parent_id)
                 if parent:
-                    if self.specimen_view.is_member(parent):
+                    if self.specimen_view.is_publishable_member(parent):
                         # we found a specimen, return the data from it
                         return self.specimen_view.transform(parent)
                     else:

--- a/dataimporter/emu/views/specimen.py
+++ b/dataimporter/emu/views/specimen.py
@@ -186,6 +186,19 @@ class SpecimenView(View):
         if record.get_first_value('ColRecordType') not in ALLOWED_TYPES:
             return INVALID_TYPE
 
+        if record.get_first_value('ColDepartment') not in DEPARTMENT_COLLECTION_CODES:
+            return INVALID_DEPARTMENT
+
+        return SUCCESS_RESULT
+
+    def is_publishable(self, record: SourceRecord) -> FilterResult:
+        """
+        Filters the given record, determining whether it matches the publishing rules
+        for specimen records.
+
+        :param record: the record to filter
+        :return: a FilterResult object
+        """
         if not is_web_published(record):
             return NO_PUBLISH
 
@@ -194,9 +207,6 @@ class SpecimenView(View):
 
         if record.get_first_value('SecRecordStatus') in DISALLOWED_STATUSES:
             return INVALID_STATUS
-
-        if record.get_first_value('ColDepartment') not in DEPARTMENT_COLLECTION_CODES:
-            return INVALID_DEPARTMENT
 
         return SUCCESS_RESULT
 

--- a/dataimporter/emu/views/taxonomy.py
+++ b/dataimporter/emu/views/taxonomy.py
@@ -11,9 +11,10 @@ class TaxonomyView(View):
     that go through this view are merged into other record types.
     """
 
-    def is_member(self, record: SourceRecord) -> FilterResult:
+    def is_publishable(self, record: SourceRecord) -> FilterResult:
         """
-        Filters the given record, determining whether it is a taxonomy record or not.
+        Filters the given record, determining whether it matches the publishing rules
+        for taxonomy records.
 
         :param record: the record to filter
         :return: a FilterResult object

--- a/dataimporter/emu/views/threed.py
+++ b/dataimporter/emu/views/threed.py
@@ -33,18 +33,28 @@ class ThreeDView(View):
         if record.get_first_value('MulDocumentType') != 'U':
             return MULTIMEDIA_NOT_URL
 
-        if not is_valid_guid(record):
-            return INVALID_GUID
-
-        if not is_web_published(record):
-            return NO_PUBLISH
-
         if record.get_first_value('DetPublisher', lower=True) not in VALID_PUBLISHERS:
             return INVALID_PUBLISHER
 
         # TODO: do we really need this?
         if record.get_first_value('DetResourceType') != 'Specimen':
             return NOT_SPECIMEN
+
+        return SUCCESS_RESULT
+
+    def is_publishable(self, record: SourceRecord) -> FilterResult:
+        """
+        Filters the given record, determining whether it matches the publishing rules
+        for 3D resource records.
+
+        :param record: the record to filter
+        :return: a FilterResult object
+        """
+        if not is_valid_guid(record):
+            return INVALID_GUID
+
+        if not is_web_published(record):
+            return NO_PUBLISH
 
         return SUCCESS_RESULT
 

--- a/dataimporter/importer.py
+++ b/dataimporter/importer.py
@@ -334,7 +334,7 @@ class DataImporter:
             changed_records = view.iter_changed()
         records = (
             Record(record.id, view.transform(record))
-            if record
+            if record and view.is_publishable(record)
             else Record.delete(record.id)
             for record in changed_records
         )

--- a/dataimporter/lib/view.py
+++ b/dataimporter/lib/view.py
@@ -158,7 +158,7 @@ class View:
         yield from (
             record
             for record in self.store.get_records(ids, yield_deleted=False)
-            if self.is_member(record)
+            if self.is_publishable_member(record)
         )
 
     def get(self, record_id: str) -> Optional[SourceRecord]:
@@ -170,7 +170,7 @@ class View:
         :return: None or a SourceRecord object
         """
         record = self.store.get_record(record_id, return_deleted=False)
-        if record is not None and self.is_member(record):
+        if record is not None and self.is_publishable_member(record):
             return record
         return None
 

--- a/dataimporter/lib/view.py
+++ b/dataimporter/lib/view.py
@@ -107,6 +107,35 @@ class View:
         """
         return SUCCESS_RESULT
 
+    def is_publishable(self, record: SourceRecord) -> FilterResult:
+        """
+        Given a record, determine whether it is published based on the rules of this
+        view. Return a FilterResult with a success=True attribute if yes, otherwise
+        return a FilterResult with a success=False attribute and a reason describing why
+        the record should not be published.
+
+        By default, this function returns a FilterResult with success=True.
+
+        :param record: the SourceRecord to check
+        :return: a FilterResult object
+        """
+        return SUCCESS_RESULT
+
+    def is_publishable_member(self, record: SourceRecord) -> FilterResult:
+        """
+        Given a record, determine whether it is first a member of this view and then is
+        publishable under the rules of this view. This functionality was previously
+        entirely contained within is_member, but has since been split into separate
+        methods.
+
+        :param record: the SourceRecord to check
+        :return: a FilterResult object
+        """
+        check_member = self.is_member(record)
+        if not check_member:
+            return check_member
+        return self.is_publishable(record)
+
     def transform(self, record: SourceRecord) -> dict:
         """
         Given a record, return a dict which will be ingested by Splitgill. This is

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,5 +1,3 @@
-version: "3"
-
 services:
   # runs the tests
   test:
@@ -16,6 +14,7 @@ services:
     volumes:
       - ./tests:/usr/src/app/tests
       - ./docker/config.yml:/usr/src/app/docker/config.yml
+      - ./dataimporter:/usr/src/app/dataimporter
 
   # serves the docs locally with realtime auto-reloading
   docs:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -19,7 +19,7 @@ classifiers = [
     "Programming Language :: Python :: 3.11",
 ]
 dependencies = [
-    "splitgill==3.1.0",
+    "splitgill==3.1.1",
     "elasticsearch==8.10.1",
     "elasticsearch-dsl==8.9.0",
     "pymongo==4.6.0",

--- a/tests/emu/views/test_image.py
+++ b/tests/emu/views/test_image.py
@@ -7,20 +7,37 @@ from dataimporter.emu.views.utils import INVALID_GUID, NO_PUBLISH
 from dataimporter.lib.model import SourceRecord
 from dataimporter.lib.view import SUCCESS_RESULT, FilterResult
 from tests.helpers.samples.image import SAMPLE_IMAGE_DATA, SAMPLE_IMAGE_ID
+from tests.helpers.utils import is_member_error, is_publishable_error
 
-is_member_scenarios: List[Tuple[dict, FilterResult]] = [
-    ({'MulMimeType': 'Document'}, MULTIMEDIA_NOT_IMAGE),
-    ({'AdmGUIDPreferredValue': 'not a valid guid!'}, INVALID_GUID),
-    ({'AdmPublishWebNoPasswordFlag': 'n'}, NO_PUBLISH),
-    ({}, SUCCESS_RESULT),
+is_publishable_member_scenarios: List[
+    Tuple[dict, FilterResult, FilterResult, FilterResult]
+] = [
+    ({'MulMimeType': 'Document'}, *is_member_error(MULTIMEDIA_NOT_IMAGE)),
+    (
+        {'AdmGUIDPreferredValue': 'not a valid guid!'},
+        *is_publishable_error(INVALID_GUID),
+    ),
+    ({'AdmPublishWebNoPasswordFlag': 'n'}, *is_publishable_error(NO_PUBLISH)),
+    ({}, SUCCESS_RESULT, SUCCESS_RESULT, SUCCESS_RESULT),
 ]
 
 
-@pytest.mark.parametrize('overrides, result', is_member_scenarios)
-def test_is_member(overrides: dict, result: FilterResult, image_view: ImageView):
+@pytest.mark.parametrize(
+    'overrides, member_result, publishable_result, publishable_member_result',
+    is_publishable_member_scenarios,
+)
+def test_is_publishable_member(
+    overrides: dict,
+    member_result: FilterResult,
+    publishable_result: FilterResult,
+    publishable_member_result: FilterResult,
+    image_view: ImageView,
+):
     data = {**SAMPLE_IMAGE_DATA, **overrides}
     record = SourceRecord(SAMPLE_IMAGE_ID, data, 'test')
-    assert image_view.is_member(record) == result
+    assert image_view.is_member(record) == member_result
+    assert image_view.is_publishable(record) == publishable_result
+    assert image_view.is_publishable_member(record) == publishable_member_result
 
 
 def test_transform(image_view: ImageView):

--- a/tests/emu/views/test_indexlot.py
+++ b/tests/emu/views/test_indexlot.py
@@ -17,22 +17,39 @@ from dataimporter.lib.view import SUCCESS_RESULT, FilterResult
 from tests.helpers.samples.image import SAMPLE_IMAGE_DATA, SAMPLE_IMAGE_ID
 from tests.helpers.samples.indexlot import SAMPLE_INDEXLOT_DATA, SAMPLE_INDEXLOT_ID
 from tests.helpers.samples.taxonomy import SAMPLE_TAXONOMY_DATA, SAMPLE_TAXONOMY_ID
+from tests.helpers.utils import is_member_error, is_publishable_error
 
-is_member_scenarios: List[Tuple[dict, FilterResult]] = [
-    ({'ColRecordType': 'Specimen'}, INVALID_TYPE),
-    ({'AdmPublishWebNoPasswordFlag': 'n'}, NO_PUBLISH),
-    ({'AdmGUIDPreferredValue': 'not a valid guid!'}, INVALID_GUID),
-    ({'SecRecordStatus': 'INVALID'}, INVALID_STATUS),
-    ({'ColDepartment': 'DDI'}, INVALID_DEPARTMENT),
-    ({}, SUCCESS_RESULT),
+is_publishable_member_scenarios: List[
+    Tuple[dict, FilterResult, FilterResult, FilterResult]
+] = [
+    ({'ColRecordType': 'Specimen'}, *is_member_error(INVALID_TYPE)),
+    ({'ColDepartment': 'DDI'}, *is_member_error(INVALID_DEPARTMENT)),
+    ({'AdmPublishWebNoPasswordFlag': 'n'}, *is_publishable_error(NO_PUBLISH)),
+    (
+        {'AdmGUIDPreferredValue': 'not a valid guid!'},
+        *is_publishable_error(INVALID_GUID),
+    ),
+    ({'SecRecordStatus': 'INVALID'}, *is_publishable_error(INVALID_STATUS)),
+    ({}, SUCCESS_RESULT, SUCCESS_RESULT, SUCCESS_RESULT),
 ]
 
 
-@pytest.mark.parametrize('overrides, result', is_member_scenarios)
-def test_is_member(overrides: dict, result: FilterResult, indexlot_view: IndexLotView):
+@pytest.mark.parametrize(
+    'overrides, member_result, publishable_result, publishable_member_result',
+    is_publishable_member_scenarios,
+)
+def test_is_publishable_member(
+    overrides: dict,
+    member_result: FilterResult,
+    publishable_result: FilterResult,
+    publishable_member_result: FilterResult,
+    indexlot_view: IndexLotView,
+):
     data = {**SAMPLE_INDEXLOT_DATA, **overrides}
     record = SourceRecord(SAMPLE_INDEXLOT_ID, data, 'test')
-    assert indexlot_view.is_member(record) == result
+    assert indexlot_view.is_member(record) == member_result
+    assert indexlot_view.is_publishable(record) == publishable_result
+    assert indexlot_view.is_publishable_member(record) == publishable_member_result
 
 
 def test_transform_no_images_no_taxonomy(indexlot_view: IndexLotView):

--- a/tests/emu/views/test_preparation.py
+++ b/tests/emu/views/test_preparation.py
@@ -27,57 +27,89 @@ from tests.helpers.samples.preparation import (
     SAMPLE_PREPARATION_ID,
 )
 from tests.helpers.samples.specimen import SAMPLE_SPECIMEN_DATA, SAMPLE_SPECIMEN_ID
+from tests.helpers.utils import is_member_error, is_publishable_error
 
-mol_prep_is_member_scenarios: List[Tuple[dict, FilterResult]] = [
-    ({'ColRecordType': 'Specimen'}, INVALID_TYPE),
+mol_prep_is_publishable_member_scenarios: List[
+    Tuple[dict, FilterResult, FilterResult, FilterResult]
+] = [
+    ({'ColRecordType': 'Specimen'}, *is_member_error(INVALID_TYPE)),
     # this is a check to make sure a mammal part in molecular collections doesn't come
     # through
-    ({'ColRecordType': 'Mammal Group Part'}, INVALID_SUB_DEPARTMENT),
-    ({'AdmPublishWebNoPasswordFlag': 'n'}, NO_PUBLISH),
-    ({'AdmGUIDPreferredValue': 'not a valid guid!'}, INVALID_GUID),
-    ({'SecRecordStatus': 'INVALID'}, INVALID_STATUS),
-    ({'ColDepartment': 'DDI'}, INVALID_DEPARTMENT),
-    ({'ColSubDepartment': 'Informatics'}, INVALID_SUB_DEPARTMENT),
-    ({'ColSubDepartment': 'LS Mammals'}, INVALID_SUB_DEPARTMENT),
-    ({'LocPermanentLocationRef': '3250522'}, ON_LOAN),
-    ({'LocCurrentSummaryData': 'ON LOAN'}, ON_LOAN),
-    ({}, SUCCESS_RESULT),
+    ({'ColRecordType': 'Mammal Group Part'}, *is_member_error(INVALID_SUB_DEPARTMENT)),
+    ({'AdmPublishWebNoPasswordFlag': 'n'}, *is_publishable_error(NO_PUBLISH)),
+    (
+        {'AdmGUIDPreferredValue': 'not a valid guid!'},
+        *is_publishable_error(INVALID_GUID),
+    ),
+    ({'SecRecordStatus': 'INVALID'}, *is_publishable_error(INVALID_STATUS)),
+    ({'ColDepartment': 'DDI'}, *is_member_error(INVALID_DEPARTMENT)),
+    ({'ColSubDepartment': 'Informatics'}, *is_member_error(INVALID_SUB_DEPARTMENT)),
+    ({'ColSubDepartment': 'LS Mammals'}, *is_member_error(INVALID_SUB_DEPARTMENT)),
+    ({'LocPermanentLocationRef': '3250522'}, *is_publishable_error(ON_LOAN)),
+    ({'LocCurrentSummaryData': 'ON LOAN'}, *is_publishable_error(ON_LOAN)),
+    ({}, SUCCESS_RESULT, SUCCESS_RESULT, SUCCESS_RESULT),
 ]
 
 
-@pytest.mark.parametrize('overrides, result', mol_prep_is_member_scenarios)
-def test_is_member_mol_prep(
-    overrides: dict, result: FilterResult, preparation_view: PreparationView
+@pytest.mark.parametrize(
+    'overrides, member_result, publishable_result, publishable_member_result',
+    mol_prep_is_publishable_member_scenarios,
+)
+def test_is_publishable_member_mol_prep(
+    overrides: dict,
+    member_result: FilterResult,
+    publishable_result: FilterResult,
+    publishable_member_result: FilterResult,
+    preparation_view: PreparationView,
 ):
     data = {**SAMPLE_PREPARATION_DATA, **overrides}
     record = SourceRecord(SAMPLE_PREPARATION_ID, data, 'test')
-    assert preparation_view.is_member(record) == result
+    assert preparation_view.is_member(record) == member_result
+    assert preparation_view.is_publishable(record) == publishable_result
+    assert preparation_view.is_publishable_member(record) == publishable_member_result
 
 
-mammal_part_prep_is_member_scenarios: List[Tuple[dict, FilterResult]] = [
-    ({'ColRecordType': 'Specimen'}, INVALID_TYPE),
-    ({'AdmPublishWebNoPasswordFlag': 'n'}, NO_PUBLISH),
-    ({'AdmGUIDPreferredValue': 'not a valid guid!'}, INVALID_GUID),
-    ({'SecRecordStatus': 'INVALID'}, INVALID_STATUS),
-    ({'ColDepartment': 'DDI'}, INVALID_DEPARTMENT),
-    ({'ColSubDepartment': 'Informatics'}, INVALID_SUB_DEPARTMENT),
-    ({'ColSubDepartment': 'Molecular Collections'}, INVALID_SUB_DEPARTMENT),
-    ({'NhmSecProjectName': 'Life of Darwin Tree'}, INVALID_PROJECT),
+mammal_part_prep_is_publishable_member_scenarios: List[
+    Tuple[dict, FilterResult, FilterResult, FilterResult]
+] = [
+    ({'ColRecordType': 'Specimen'}, *is_member_error(INVALID_TYPE)),
+    ({'AdmPublishWebNoPasswordFlag': 'n'}, *is_publishable_error(NO_PUBLISH)),
+    (
+        {'AdmGUIDPreferredValue': 'not a valid guid!'},
+        *is_publishable_error(INVALID_GUID),
+    ),
+    ({'SecRecordStatus': 'INVALID'}, *is_publishable_error(INVALID_STATUS)),
+    ({'ColDepartment': 'DDI'}, *is_member_error(INVALID_DEPARTMENT)),
+    ({'ColSubDepartment': 'Informatics'}, *is_member_error(INVALID_SUB_DEPARTMENT)),
+    (
+        {'ColSubDepartment': 'Molecular Collections'},
+        *is_member_error(INVALID_SUB_DEPARTMENT),
+    ),
+    ({'NhmSecProjectName': 'Life of Darwin Tree'}, *is_member_error(INVALID_PROJECT)),
     # this is a check to make sure a prep in LS Mammals doesn't come through
-    ({'ColRecordType': 'Preparation'}, INVALID_SUB_DEPARTMENT),
-    ({'LocPermanentLocationRef': '3250522'}, ON_LOAN),
-    ({'LocCurrentSummaryData': 'ON LOAN'}, ON_LOAN),
-    ({}, SUCCESS_RESULT),
+    ({'ColRecordType': 'Preparation'}, *is_member_error(INVALID_SUB_DEPARTMENT)),
+    ({'LocPermanentLocationRef': '3250522'}, *is_publishable_error(ON_LOAN)),
+    ({'LocCurrentSummaryData': 'ON LOAN'}, *is_publishable_error(ON_LOAN)),
+    ({}, SUCCESS_RESULT, SUCCESS_RESULT, SUCCESS_RESULT),
 ]
 
 
-@pytest.mark.parametrize('overrides, result', mammal_part_prep_is_member_scenarios)
-def test_is_member_mammal_part_prep(
-    overrides: dict, result: FilterResult, preparation_view: PreparationView
+@pytest.mark.parametrize(
+    'overrides, member_result, publishable_result, publishable_member_result',
+    mammal_part_prep_is_publishable_member_scenarios,
+)
+def test_is_publishable_member_mammal_part_prep(
+    overrides: dict,
+    member_result: FilterResult,
+    publishable_result: FilterResult,
+    publishable_member_result: FilterResult,
+    preparation_view: PreparationView,
 ):
     data = {**SAMPLE_MAMMAL_PREPARATION_DATA, **overrides}
     record = SourceRecord(SAMPLE_MAMMAL_PREPARATION_ID, data, 'test')
-    assert preparation_view.is_member(record) == result
+    assert preparation_view.is_member(record) == member_result
+    assert preparation_view.is_publishable(record) == publishable_result
+    assert preparation_view.is_publishable_member(record) == publishable_member_result
 
 
 def test_transform_mol_prep(preparation_view: PreparationView):

--- a/tests/emu/views/test_taxonomy.py
+++ b/tests/emu/views/test_taxonomy.py
@@ -7,18 +7,32 @@ from dataimporter.emu.views.utils import NO_PUBLISH
 from dataimporter.lib.model import SourceRecord
 from dataimporter.lib.view import SUCCESS_RESULT, FilterResult
 from tests.helpers.samples.taxonomy import SAMPLE_TAXONOMY_DATA, SAMPLE_TAXONOMY_ID
+from tests.helpers.utils import is_publishable_error
 
-is_member_scenarios: List[Tuple[dict, FilterResult]] = [
-    ({'AdmPublishWebNoPasswordFlag': 'n'}, NO_PUBLISH),
-    ({}, SUCCESS_RESULT),
+is_publishable_member_scenarios: List[
+    Tuple[dict, FilterResult, FilterResult, FilterResult]
+] = [
+    ({'AdmPublishWebNoPasswordFlag': 'n'}, *is_publishable_error(NO_PUBLISH)),
+    ({}, SUCCESS_RESULT, SUCCESS_RESULT, SUCCESS_RESULT),
 ]
 
 
-@pytest.mark.parametrize('overrides, result', is_member_scenarios)
-def test_is_member(overrides: dict, result: FilterResult, taxonomy_view: TaxonomyView):
+@pytest.mark.parametrize(
+    'overrides, member_result, publishable_result, publishable_member_result',
+    is_publishable_member_scenarios,
+)
+def test_is_publishable_member(
+    overrides: dict,
+    member_result: FilterResult,
+    publishable_result: FilterResult,
+    publishable_member_result: FilterResult,
+    taxonomy_view: TaxonomyView,
+):
     data = {**SAMPLE_TAXONOMY_DATA, **overrides}
     record = SourceRecord(SAMPLE_TAXONOMY_ID, data, 'test')
-    assert taxonomy_view.is_member(record) == result
+    assert taxonomy_view.is_member(record) == member_result
+    assert taxonomy_view.is_publishable(record) == publishable_result
+    assert taxonomy_view.is_publishable_member(record) == publishable_member_result
 
 
 def test_make_data(taxonomy_view: TaxonomyView):

--- a/tests/helpers/utils.py
+++ b/tests/helpers/utils.py
@@ -1,0 +1,36 @@
+# !/usr/bin/env python
+# encoding: utf-8
+
+from typing import Tuple
+
+from dataimporter.lib.view import SUCCESS_RESULT, FilterResult
+
+
+def is_member_error(
+    filter_error: FilterResult,
+) -> Tuple[FilterResult, FilterResult, FilterResult]:
+    """
+    Get a tuple of filter responses that would be returned from is_member,
+    is_publishable, and is_publishable_member respectively, where is_member does not
+    return a success result. Convenience function used in
+    is_publishable_member_scenarios.
+
+    :param filter_error: the error returned by is_member
+    :return: a tuple of filter results where the first and last are the same
+    """
+    return filter_error, SUCCESS_RESULT, filter_error
+
+
+def is_publishable_error(
+    filter_error: FilterResult,
+) -> Tuple[FilterResult, FilterResult, FilterResult]:
+    """
+    Get a tuple of filter responses that would be returned from is_member,
+    is_publishable, and is_publishable_member respectively, where is_publishable does
+    not  return a success result. Convenience function used in
+    is_publishable_member_scenarios.
+
+    :param filter_error: the error returned by is_publishable
+    :return: a tuple of filter results where the second and last are the same
+    """
+    return SUCCESS_RESULT, filter_error, filter_error

--- a/tests/test_importer.py
+++ b/tests/test_importer.py
@@ -5,6 +5,7 @@ from unittest.mock import MagicMock, patch
 
 import pytest
 from freezegun import freeze_time
+from splitgill.model import Record
 from splitgill.search import keyword
 from splitgill.utils import to_timestamp
 
@@ -717,6 +718,138 @@ class TestDataImporter:
             )
             # check it still exists in the previous version
             assert database.search(first_version).count() == 8
+
+    @pytest.mark.usefixtures('reset_mongo', 'reset_elasticsearch')
+    def test_purge_records(self, config: Config):
+        name = 'artefact'
+        # create some artefact records
+        artefact_records = [
+            create_ecatalogue(
+                str(i),
+                EcatalogueType[name],
+                PalArtObjectName=f'{i} beans',
+            )
+            for i in range(1, 9)
+        ]
+        first_dump_date = date(2025, 1, 1)
+        # create an ecatalogue dump with 8 artefacts
+        create_dump(
+            config.dumps_path,
+            'ecatalogue',
+            first_dump_date,
+            *artefact_records,
+        )
+        # make two records unpublishable and one no longer an artefact
+        depublished_record_1 = artefact_records[0]
+        depublished_record_1['SecRecordStatus'] = 'Retired'
+        depublished_record_2 = artefact_records[1]
+        depublished_record_2['AdmPublishWebNoPasswordFlag'] = 'N'
+        non_member_record = artefact_records[2]
+        non_member_record['ColRecordType'] = 'Banana'
+        test_records = [depublished_record_1, depublished_record_2, non_member_record]
+        # update the name for all of them so mongo recognises it as a change later
+        for ix, tr in enumerate(test_records):
+            tr.update({'PalArtObjectName': f'{ix} beanz'})
+        second_dump = create_dump(
+            config.dumps_path, 'ecatalogue', date(2025, 1, 3), *test_records
+        )
+
+        with use_importer(config) as importer, freeze_time('2025-01-02') as frozen_time:
+            view = importer.get_view(name)
+            db = importer.get_database(view)
+
+            # import the first dump and check all 8 records are present
+            importer.queue_emu_changes()
+            importer.add_to_mongo(name)
+            database = importer.get_database(importer.get_view(name))
+            importer.sync_to_elasticsearch(name)
+            first_db_version = database.get_committed_version()
+            first_es_version = database.get_elasticsearch_version()
+            search_base = database.search()
+
+            assert database.data_collection.count_documents({}) == 8
+            assert search_base.count() == 8
+
+            for test_record in test_records:
+                mongo_record = database.data_collection.find_one(
+                    {'id': test_record['irn']}
+                )
+                assert mongo_record is not None
+                assert len(mongo_record['data']) > 0
+                assert 'diffs' not in mongo_record
+                assert (
+                    search_base.filter(
+                        'term',
+                        **{keyword('_id'): test_record['irn']},
+                    ).count()
+                    == 1
+                )
+
+            frozen_time.tick(timedelta(days=2))  # advance forward 2 days
+
+            # force update the two invalid records (doing a normal ingest would
+            # automatically remove the depublished record)
+            source_records = [
+                SourceRecord(r['irn'], r, second_dump.name) for r in test_records
+            ]
+            view.store.put(source_records)
+            records = [Record(r.id, view.transform(r)) for r in source_records]
+            db.ingest(records, modified_field='modified')
+            second_db_version = db.get_committed_version()
+            assert second_db_version != first_db_version
+            importer.sync_to_elasticsearch(name)
+            second_es_version = db.get_elasticsearch_version()
+            assert second_es_version != first_es_version
+
+            # check all 8 records are still present and contain data
+            assert database.data_collection.count_documents({}) == 8
+            assert search_base.count() == 8
+            for test_record in test_records:
+                mongo_record = database.data_collection.find_one(
+                    {'id': test_record['irn']}
+                )
+                assert mongo_record is not None
+                assert len(mongo_record['data']) > 0
+                # check the source record has been updated
+                source_record = view.store.get_record(mongo_record['id'])
+                assert not view.is_publishable_member(source_record)
+                assert (
+                    search_base.filter(
+                        'term',
+                        **{keyword('artefactName'): test_record['PalArtObjectName']},
+                    ).count()
+                    == 1
+                )
+
+            frozen_time.tick(timedelta(days=1))  # advance forward 1 day
+
+            # now purge and check that they're all deleted
+            non_member_count, non_publishable_count, total_deleted = (
+                importer.purge_unsuitable_records(name)
+            )
+            final_db_version = db.get_committed_version()
+            assert final_db_version != second_db_version
+            importer.sync_to_elasticsearch(name)
+            final_es_version = db.get_elasticsearch_version()
+            assert final_es_version != second_es_version
+            assert non_member_count == 1
+            assert non_publishable_count == 2
+            assert total_deleted == 3
+            # they should still exist in mongo
+            assert database.data_collection.count_documents({}) == 8
+            # but they shouldn't have any current data
+            for test_record in test_records:
+                mongo_record = database.data_collection.find_one(
+                    {'id': test_record['irn']}
+                )
+                assert mongo_record is not None
+                assert len(mongo_record['data']) == 0
+                assert len(mongo_record['diffs']) == 2
+            # they shouldn't exist in current elasticsearch
+            assert search_base.count() == 5
+            # but they should in the previous versions
+            assert database.search(first_es_version).count() == 8
+            assert database.search(second_es_version).count() == 8
 
 
 class TestEMuStatus:

--- a/tests/test_importer.py
+++ b/tests/test_importer.py
@@ -652,6 +652,7 @@ class TestDataImporter:
             for i in range(1, 9)
         ]
         first_dump_date = date(2025, 1, 1)
+
         # create an ecatalogue dump with 8 artefacts
         create_dump(
             config.dumps_path,
@@ -659,33 +660,38 @@ class TestDataImporter:
             first_dump_date,
             *artefact_records,
         )
+
+        target_record = artefact_records[0]
+
         # create dump that depublishes one of those records
-        second_dump_date = date(2025, 1, 3)
-        updated_record = artefact_records[0]
-        updated_record['SecRecordStatus'] = 'Retired'
-        create_dump(config.dumps_path, 'ecatalogue', second_dump_date, updated_record)
+        depub_dump_date = date(2025, 1, 3)
+        depub_record = target_record.copy()
+        depub_record['AdmPublishWebNoPasswordFlag'] = 'N'
+        create_dump(config.dumps_path, 'ecatalogue', depub_dump_date, depub_record)
 
         with use_importer(config) as importer, freeze_time('2025-01-02') as frozen_time:
             # import the first dump and check all 8 records are present
             importer.queue_emu_changes()
             importer.add_to_mongo(name)
             database = importer.get_database(importer.get_view(name))
+            first_db_version = database.get_committed_version()
+            importer.sync_to_elasticsearch(name)
+            first_es_version = database.get_elasticsearch_version()
+            search_base = database.search()
+
             assert database.data_collection.count_documents({}) == 8
             mongo_record = database.data_collection.find_one(
-                {'id': updated_record['irn']}
+                {'id': target_record['irn']}
             )
             assert mongo_record is not None
             assert len(mongo_record['data']) == 2
             assert 'diffs' not in mongo_record
 
-            importer.sync_to_elasticsearch(name)
-            first_version = database.get_elasticsearch_version()
-            search_base = database.search()
             assert search_base.count() == 8
             assert (
                 search_base.filter(
                     'term',
-                    **{keyword('artefactName'): updated_record['PalArtObjectName']},
+                    **{keyword('artefactName'): target_record['PalArtObjectName']},
                 ).count()
                 == 1
             )
@@ -696,28 +702,162 @@ class TestDataImporter:
 
             importer.queue_emu_changes()
             importer.add_to_mongo(name)
-            database = importer.get_database(importer.get_view(name))
+            second_db_version = database.get_committed_version()
+            assert second_db_version != first_db_version
+            importer.sync_to_elasticsearch(name)
+            second_es_version = database.get_elasticsearch_version()
+            assert second_es_version != first_es_version
+
             # it still exists in mongo; it hasn't been redacted
             assert database.data_collection.count_documents({}) == 8
             # but there shouldn't be any data in it
             updated_mongo_record = database.data_collection.find_one(
-                {'id': updated_record['irn']}
+                {'id': target_record['irn']}
             )
             assert updated_mongo_record is not None
             assert len(updated_mongo_record['data']) == 0
             assert len(updated_mongo_record['diffs']) == 1
 
-            importer.sync_to_elasticsearch(name)
+            # it shouldn't be in current elasticsearch
             assert search_base.count() == 7
             assert (
                 search_base.filter(
                     'term',
-                    **{keyword('artefactName'): updated_record['PalArtObjectName']},
+                    **{keyword('artefactName'): target_record['PalArtObjectName']},
                 ).count()
                 == 0
             )
             # check it still exists in the previous version
-            assert database.search(first_version).count() == 8
+            assert database.search(first_es_version).count() == 8
+
+    @pytest.mark.usefixtures('reset_mongo', 'reset_elasticsearch')
+    def test_republish_records(self, config: Config):
+        name = 'artefact'
+        # create some artefact records
+        artefact_records = [
+            create_ecatalogue(
+                str(i),
+                EcatalogueType[name],
+                PalArtObjectName=f'{i} beans',
+            )
+            for i in range(1, 9)
+        ]
+        first_dump_date = date(2025, 1, 1)
+
+        # create an ecatalogue dump with 8 artefacts
+        create_dump(
+            config.dumps_path,
+            'ecatalogue',
+            first_dump_date,
+            *artefact_records,
+        )
+
+        target_record = artefact_records[0]
+
+        # create dump that depublishes one of those records
+        depub_dump_date = date(2025, 1, 3)
+        depub_record = target_record.copy()
+        depub_record['AdmPublishWebNoPasswordFlag'] = 'N'
+        create_dump(config.dumps_path, 'ecatalogue', depub_dump_date, depub_record)
+
+        # create a third dump that REpublishes that record
+        repub_dump_date = date(2025, 1, 5)
+        repub_record = target_record.copy()
+        repub_record['AdmPublishWebNoPasswordFlag'] = 'Y'
+        create_dump(config.dumps_path, 'ecatalogue', repub_dump_date, repub_record)
+
+        with use_importer(config) as importer, freeze_time('2025-01-02') as frozen_time:
+            # import the first dump and check all 8 records are present
+            importer.queue_emu_changes()
+            importer.add_to_mongo(name)
+            database = importer.get_database(importer.get_view(name))
+            first_db_version = database.get_committed_version()
+            importer.sync_to_elasticsearch(name)
+            first_es_version = database.get_elasticsearch_version()
+            search_base = database.search()
+
+            assert database.data_collection.count_documents({}) == 8
+            mongo_record = database.data_collection.find_one(
+                {'id': target_record['irn']}
+            )
+            assert mongo_record is not None
+            assert len(mongo_record['data']) > 0
+            assert 'diffs' not in mongo_record
+
+            assert search_base.count() == 8
+            assert (
+                search_base.filter(
+                    'term',
+                    **{keyword('artefactName'): target_record['PalArtObjectName']},
+                ).count()
+                == 1
+            )
+
+            frozen_time.tick(timedelta(days=2))  # advance forward 2 days
+
+            # import the second dump and check that one has been removed from the
+            # current version
+            importer.queue_emu_changes()
+            importer.add_to_mongo(name)
+            second_db_version = database.get_committed_version()
+            assert second_db_version != first_db_version
+            importer.sync_to_elasticsearch(name)
+            second_es_version = database.get_elasticsearch_version()
+            assert second_es_version != first_es_version
+
+            # it still exists in mongo; it hasn't been redacted
+            assert database.data_collection.count_documents({}) == 8
+            # but there shouldn't be any data in it
+            depub_mongo_record = database.data_collection.find_one(
+                {'id': target_record['irn']}
+            )
+            assert depub_mongo_record is not None
+            assert len(depub_mongo_record['data']) == 0
+            assert len(depub_mongo_record['diffs']) == 1
+
+            # it shouldn't be in current elasticsearch
+            assert search_base.count() == 7
+            assert (
+                search_base.filter(
+                    'term',
+                    **{keyword('artefactName'): target_record['PalArtObjectName']},
+                ).count()
+                == 0
+            )
+            # check it still exists in the previous version
+            assert database.search(first_es_version).count() == 8
+
+            frozen_time.tick(timedelta(days=2))  # advance forward 2 days
+
+            # import the third dump and check that it has been added back
+            importer.queue_emu_changes()
+            importer.add_to_mongo(name)
+            third_db_version = database.get_committed_version()
+            assert third_db_version != second_db_version
+            importer.sync_to_elasticsearch(name)
+            third_es_version = database.get_elasticsearch_version()
+            assert third_es_version != second_es_version
+
+            assert database.data_collection.count_documents({}) == 8
+            # there should now be data in the mongo record again
+            repub_mongo_record = database.data_collection.find_one(
+                {'id': target_record['irn']}
+            )
+            assert repub_mongo_record is not None
+            assert len(repub_mongo_record['data']) > 0
+            assert len(repub_mongo_record['diffs']) == 2
+
+            assert search_base.count() == 8
+            assert (
+                search_base.filter(
+                    'term',
+                    **{keyword('artefactName'): target_record['PalArtObjectName']},
+                ).count()
+                == 1
+            )
+            # check the previous versions are still correct
+            assert database.search(first_es_version).count() == 8
+            assert database.search(second_es_version).count() == 7
 
     @pytest.mark.usefixtures('reset_mongo', 'reset_elasticsearch')
     def test_purge_records(self, config: Config):

--- a/tests/test_view.py
+++ b/tests/test_view.py
@@ -1,5 +1,5 @@
 from pathlib import Path
-from unittest.mock import MagicMock
+from unittest.mock import MagicMock, patch
 
 import pytest
 from freezegun import freeze_time
@@ -27,6 +27,24 @@ class TestView:
     def test_is_member(self, view: View):
         # default success
         assert view.is_member(MagicMock())
+
+    def test_is_publishable(self, view: View):
+        # default success
+        assert view.is_publishable(MagicMock())
+
+    def test_is_publishable_member(self, view: View):
+        # default success
+        assert view.is_publishable_member(MagicMock())
+
+    def test_is_publishable_member_returns_member_error(self, view: View):
+        with patch.object(view, 'is_member', return_value=FilterResult(False, 'bad')):
+            assert not view.is_publishable_member(MagicMock())
+
+    def test_is_publishable_member_returns_publishable_error(self, view: View):
+        with patch.object(
+            view, 'is_publishable', return_value=FilterResult(False, 'bad')
+        ):
+            assert not view.is_publishable_member(MagicMock())
 
     def test_transform(self, view: View):
         assert view.transform(SourceRecord('1', {'a': 'b'}, 'test')) == {'a': 'b'}


### PR DESCRIPTION
- #60 
- #61 
- #62
- #63

Previously:
- records were assigned to views based on attributes checked by the `is_member()` method
- these attributes could be things like `recordType == 'Specimen'` or `recordStatus != 'Retired'` (simplified examples)
- if a record stopping matching these criteria, any further updates would be ignored by the ingest
- it would not be deleted or updated in any way except in the LevelDB stores
- the main problem with this was for records that were newly marked as "retired" or "do not publish on web"; these updates were ignored because the record was no longer considered part of the view

Now:
- the attributes in `is_member()` have been split into `is_member()` (attributes defining fundamental membership of the view, e.g. `recordType == 'Specimen'`) and `is_publishable()` (attributes defining whether it can currently be published to the data portal, e.g. `recordStatus != 'Retired'`)
- views ingest records that match their `is_member()` rules (this increases the number of records processed by each view, but by a reasonable amount and it's necessary)
- records that don't match the `is_publishable()` rules of the get deleted from the current version
- records that have stopped matching the `is_member()` rules still don't get automatically deleted, so there's also a new `dimp view purge` command that removes both types of unsuitable record; this can be run as a cron on a much less regular basis